### PR TITLE
Nightly compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
     - secure: ZZu7tW/Uy+ZLQepLoksudhAGhmL8gV3riCo7gq6aUIEuPKz2qQf8WaYQxm2/W5VORaD6jWSDINONs2wNeK7lsZ0X11DoW7uQeMu8ysqFCWAjNj0xzBcH1IfzFSFo5cobYOCEQzSvLE3f+TyL2meIXheJNlQYF8eukILzT0x8GLE=
 before_script:
-- rustc -v
+- rustc -V
 - cargo -V
 script:
 - cargo build -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "img_hash"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 
 description = "A simple library that provides perceptual hashing and difference calculation for images."

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -1,5 +1,5 @@
 use std::f64::consts::{PI, SQRT2};
-use std::num::FloatMath;
+use std::num::Float;
 
 pub fn dct_2d(packed_2d: &[f64], width: uint, height: uint) -> Vec<f64> {
     assert!(packed_2d.len() == width * height, 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ type LumaBuf = ImageBuffer<Vec<u8>, u8, Luma<u8>>;
 /// For efficiency, does not retain a copy of the image data after hashing.
 ///
 /// Get an instance with `ImageHash::hash()`.
-#[deriving(PartialEq, Eq, Hash, Show, Clone)]
+#[derive(PartialEq, Eq, Hash, Show, Clone)]
 pub struct ImageHash {
     size: u32,
     bitv: Bitv,


### PR DESCRIPTION
Just made a few changes so that this compiles with the latest version of 
rust as of now:

```
$ rustc --version
rustc 1.0.0-nightly (ea6f65c5f 2015-01-06 19:47:08 +0000)
```