### PR TITLE
fields of ImageHash are now public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@ type LumaBuf = ImageBuffer<Vec<u8>, u8, Luma<u8>>;
 /// Get an instance with `ImageHash::hash()`.
 #[derive(PartialEq, Eq, Hash, Show, Clone)]
 pub struct ImageHash {
-    size: u32,
-    bitv: Bitv,
+    pub size: u32,
+    pub bitv: Bitv,
 }
 
 impl ImageHash {


### PR DESCRIPTION
to be able to serialize the calculated image hash within an external project, access to bitv and size is needed