### PR TITLE
introduced from_base64(), replaced size and hash_size() by size(), replaced all uint by usize

### DIFF
--- a/src/dct.rs
+++ b/src/dct.rs
@@ -1,7 +1,7 @@
 use std::f64::consts::{PI, SQRT2};
 use std::num::Float;
 
-pub fn dct_2d(packed_2d: &[f64], width: uint, height: uint) -> Vec<f64> {
+pub fn dct_2d(packed_2d: &[f64], width: usize, height: usize) -> Vec<f64> {
     assert!(packed_2d.len() == width * height, 
             "Slice length must be width * height!");
 
@@ -18,7 +18,7 @@ pub fn dct_2d(packed_2d: &[f64], width: uint, height: uint) -> Vec<f64> {
     from_columns(dct_columns, width, height)
 }
 
-fn rows(packed_2d: Vec<f64>, width: uint, height: uint) -> Vec<Vec<f64>> {
+fn rows(packed_2d: Vec<f64>, width: usize, height: usize) -> Vec<Vec<f64>> {
     let mut rows: Vec<Vec<f64>> = Vec::new();
 
     for y in range(0, height) {
@@ -30,7 +30,7 @@ fn rows(packed_2d: Vec<f64>, width: uint, height: uint) -> Vec<Vec<f64>> {
     rows
 }
 
-fn columns(rows: Vec<Vec<f64>>, width: uint, height: uint) -> Vec<Vec<f64>> {
+fn columns(rows: Vec<Vec<f64>>, width: usize, height: usize) -> Vec<Vec<f64>> {
     let mut columns: Vec<Vec<f64>> = Vec::new();
 
     for x in range(0, width) {
@@ -46,7 +46,7 @@ fn columns(rows: Vec<Vec<f64>>, width: uint, height: uint) -> Vec<Vec<f64>> {
     columns
 }
 
-fn from_columns(columns: Vec<Vec<f64>>, width: uint, height: uint) -> Vec<f64> {
+fn from_columns(columns: Vec<Vec<f64>>, width: usize, height: usize) -> Vec<f64> {
     let mut packed = Vec::new();
 
     for y in range(0, height) {
@@ -84,7 +84,7 @@ fn dct_1d(vec: &[f64]) -> Vec<f64> {
     out
 }
 
-pub fn crop_dct(dct: Vec<f64>, original: (uint, uint), new: (uint, uint)) 
+pub fn crop_dct(dct: Vec<f64>, original: (usize, usize), new: (usize, usize)) 
     -> Vec<f64> {
     let mut out = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ impl ImageHash {
     /// Equivalent to counting the 1-bits of the XOR of the two `Bitv`.
     /// 
     /// Essential to determining the perceived difference between `self` and `other`.
-    pub fn dist(&self, other: &ImageHash) -> uint {
+    pub fn dist(&self, other: &ImageHash) -> usize {
         assert!(self.bitv.len() == other.bitv.len(), 
                 "ImageHashes must be the same length for proper comparison!");
 
@@ -75,7 +75,7 @@ impl ImageHash {
             dct_hash(img, hash_size)
         };
 
-        assert!((hash_size * hash_size) as uint == hash.len());
+        assert!((hash_size * hash_size) as usize == hash.len());
 
         ImageHash {
             bitv: hash,
@@ -113,12 +113,12 @@ fn fast_hash<Img: GenericImage<Rgba<u8>>>(img: &Img, hash_size: u32) -> Bitv {
 
     let hash_values: Vec<u8> = temp.pixels().map(|px| px.channels()[0]).collect();
 
-    let hash_sq = (hash_size * hash_size) as uint;
+    let hash_sq = (hash_size * hash_size) as usize;
 
-    let mean = hash_values.iter().fold(0u, |b, &a| a as uint + b) 
+    let mean = hash_values.iter().fold(0us, |b, &a| a as usize + b) 
         / hash_sq;
 
-    hash_values.into_iter().map(|x| x as uint >= mean).collect()
+    hash_values.into_iter().map(|x| x as usize >= mean).collect()
 }
 
 fn dct_hash<Img: GenericImage<Rgba<u8>>>(img: &Img, hash_size: u32) -> Bitv {
@@ -132,10 +132,10 @@ fn dct_hash<Img: GenericImage<Rgba<u8>>>(img: &Img, hash_size: u32) -> Bitv {
     let hash_values: Vec<f64> = temp.pixels().map(|px| px.channels()[0] as f64).collect();
 
     let dct = dct_2d(hash_values.as_slice(),
-        large_size as uint, large_size as uint);
+        large_size as usize, large_size as usize);
 
-    let original = (large_size as uint, large_size as uint);
-    let new = (hash_size as uint, hash_size as uint);
+    let original = (large_size as usize, large_size as usize);
+    let new = (hash_size as usize, hash_size as usize);
 
     let cropped_dct = crop_dct(dct, original, new);
 
@@ -160,7 +160,7 @@ mod test {
     type RgbaBuf = ImageBuffer<Vec<u8>, u8, Rgba<u8>>;
 
     fn gen_test_img(width: u32, height: u32) -> RgbaBuf {
-        let len = (width * height * 4) as uint;
+        let len = (width * height * 4) as usize;
         let mut buf = Vec::with_capacity(len);
         unsafe { buf.set_len(len); } // We immediately fill the buffer.
         weak_rng().fill_bytes(&mut *buf);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,7 @@ impl ImageHash {
         }
     }
 
-    /// Creates a Hash from Base64 string representing the bits of a hash.
-    ///
-    /// This is the counterpart of to_base64().
+    /// Create an `ImageHash` instance from the given Base64-encoded string.
     pub fn from_base64(encoded_hash: &str) -> Result<ImageHash, FromBase64Error>{
         let data = try!(encoded_hash.from_base64());
 


### PR DESCRIPTION
- Introduced method 'from_base64(...)' for deserialization
- Removed the field 'size' from ImageHash
- Renamed hash_size() to size()
- Replaced all occurences of uint with usize (uint has become deprecated)