### PR TITLE
Use approximate of cosine

### DIFF
--- a/src/dct.rs
+++ b/src/dct.rs
@@ -68,8 +68,8 @@ fn dct_1d(vec: &[f64]) -> Vec<f64> {
         let mut z = 0f64;
 
         for x in 0 .. vec.len() {
-            z += vec[x] * (f64_consts::PI * u as f64 * (2 * x + 1) as f64 
-                / (2 * vec.len()) as f64).cos(); 
+            z += vec[x] * cos_approx(f64_consts::PI * u as f64 * (2 * x + 1) as f64 
+                / (2 * vec.len()) as f64); 
         }
 
         if u == 0 {
@@ -101,5 +101,16 @@ pub fn crop_dct(dct: Vec<f64>, original: (usize, usize), new: (usize, usize)) ->
     }
 
     out
+}
+
+/// Approximate `cos(x)` using a 4-term Taylor series. Can be expanded for higher precision.
+#[inline(always)]
+fn cos_approx(x: f64) -> f64 {
+    let x2 = x.powi(2);
+    let x4 = x2.powi(2);
+    let x6 = x4.powi(2);
+    let x8 = x6.powi(2);
+
+    1.0 - (x2 / 2.0) + (x4 / 24.0) - (x6 / 720.0) + (x8 / 40320.0)
 }
 


### PR DESCRIPTION
```
$ git checkout master
Your branch is up-to-date with 'origin/master'.
Switched to branch 'master'

$ cargo bench
   Compiling img_hash v0.5.0 (file:///C:/users/austin/rust/img_hash)
     Running target\release\img_hash-c9e2676bd7436a97.exe

running 9 tests
test test::base64_encoding_decoding ... ignored
test test::dct_2d_equality ... ignored
test test::dct_2d_inequality ... ignored
test test::hash_equality ... ignored
test test::size ... ignored
test test::bench_dbl_gradient_hash ... bench:   2415534 ns/iter (+/- 57146)
test test::bench_dct_hash          ... bench:   5045323 ns/iter (+/- 109516)
test test::bench_gradient_hash     ... bench:   2416856 ns/iter (+/- 33007)
test test::bench_mean_hash         ... bench:   2432420 ns/iter (+/- 45323)

test result: ok. 0 passed; 0 failed; 5 ignored; 4 measured

$ git checkout cos-approx
Switched to branch 'cos-approx'

$ cargo bench
   Compiling img_hash v0.5.0 (file:///C:/users/austin/rust/img_hash)
     Running target\release\img_hash-c9e2676bd7436a97.exe

running 9 tests
test test::base64_encoding_decoding ... ignored
test test::dct_2d_equality ... ignored
test test::dct_2d_inequality ... ignored
test test::hash_equality ... ignored
test test::size ... ignored
test test::bench_dbl_gradient_hash ... bench:   2414109 ns/iter (+/- 14321)
test test::bench_dct_hash          ... bench:   3430860 ns/iter (+/- 21032)
test test::bench_gradient_hash     ... bench:   2416827 ns/iter (+/- 26945)
test test::bench_mean_hash         ... bench:   2430505 ns/iter (+/- 50272)

test result: ok. 0 passed; 0 failed; 5 ignored; 4 measured
```

Approximately 32% speedup by using a 4-term Taylor-series approximation of cosine instead of `f64::cos()`. Extra terms can be added for higher precision. Passes all tests.