### PR TITLE
Add Path dependency to example program

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Example program:
 extern crate image;
 extern crate img_hash;
 
+use std::path::Path;
 use img_hash::{ImageHash, HashType};
 
 fn main() {


### PR DESCRIPTION
It didn't work for me until I added the Path import. This might be obvious to seasoned Rust programmers, but I'm just starting and I found it rather confusing.