### PR TITLE
Don't try and hash if the data is empty

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,9 @@ extern crate image;
 
 extern crate rustc_serialize as serialize;
 
-use serialize::base64::{ToBase64, STANDARD, FromBase64, FromBase64Error};
-use serialize::base64::FromBase64Error::*;
+use serialize::base64::{ToBase64, FromBase64, STANDARD};
+// Needs to be fully qualified
+pub use serialize::base64::FromBase64Error;
 
 use bit_vec::BitVec;
 
@@ -411,6 +412,8 @@ fn crop_2d_dct(packed: &[f64], original: (usize, usize), new: (usize, usize)) ->
 mod test {
     extern crate rand;
 
+    use serialize::base64::*;
+
     use image::{Rgba, ImageBuffer};
 
     use self::rand::{weak_rng, Rng};
@@ -488,13 +491,10 @@ mod test {
     #[test]
     fn base64_error_on_empty() {
         let decoded_result = ImageHash::from_base64("");
-        assert!(decoded_result.is_err());
-        /* FIXME: Figure out how to make the below run
         match decoded_result {
-            Err(FromBase64Error::InvalidBase64Length) => assert!(true),
-            Err(InvalidBase64Byte) => assert!(false, "Expected a invalid length error"),
-            Ok(_) => assert!(false, "Expected a invalid length error"),
-        };*/
+            Err(InvalidBase64Length) => (),
+            _ => panic!("Expected a invalid length error")
+        };
     }
 
     #[cfg(feature = "bench")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ impl ImageHash {
     /// Create an `ImageHash` instance from the given Base64-encoded string.
     /// ## Note:
     /// **Not** compatible with Base64-encoded strings created before `HashType` was added.
-    ///
+    /// Returns a FromBase64Error::InvalidBase64Length when trying to hash a zero-length string
     /// Does **not** preserve the internal value of `HashType::UserDCT`.
     pub fn from_base64(encoded_hash: &str) -> Result<ImageHash, FromBase64Error>{
         let mut data = try!(encoded_hash.from_base64());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,10 @@ impl ImageHash {
     /// Create an `ImageHash` instance from the given Base64-encoded string.
     /// ## Note:
     /// **Not** compatible with Base64-encoded strings created before `HashType` was added.
-    /// Returns a FromBase64Error::InvalidBase64Length when trying to hash a zero-length string
+    ///
     /// Does **not** preserve the internal value of `HashType::UserDCT`.
+    /// ## Errors:
+    /// Returns a FromBase64Error::InvalidBase64Length when trying to hash a zero-length string
     pub fn from_base64(encoded_hash: &str) -> Result<ImageHash, FromBase64Error>{
         let mut data = try!(encoded_hash.from_base64());
         // The hash type should be the first bit of the hash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ extern crate image;
 extern crate rustc_serialize as serialize;
 
 use serialize::base64::{ToBase64, STANDARD, FromBase64, FromBase64Error};
+use serialize::base64::FromBase64Error::*;
 
 use bit_vec::BitVec;
 
@@ -135,6 +136,9 @@ impl ImageHash {
     pub fn from_base64(encoded_hash: &str) -> Result<ImageHash, FromBase64Error>{
         let mut data = try!(encoded_hash.from_base64());
         // The hash type should be the first bit of the hash
+        if data.len() == 0 {
+            return Err(FromBase64Error::InvalidBase64Length);
+        }
         let hash_type = HashType::from_byte(data.remove(0));
 
         Ok(ImageHash{
@@ -481,7 +485,19 @@ mod test {
         assert_eq!(decoded_result.unwrap(), hash1);
     }  
 
-    #[cfg(feature = "bench")] 
+    #[test]
+    fn base64_error_on_empty() {
+        let decoded_result = ImageHash::from_base64("");
+        assert!(decoded_result.is_err());
+        /* FIXME: Figure out how to make the below run
+        match decoded_result {
+            Err(FromBase64Error::InvalidBase64Length) => assert!(true),
+            Err(InvalidBase64Byte) => assert!(false, "Expected a invalid length error"),
+            Ok(_) => assert!(false, "Expected a invalid length error"),
+        };*/
+    }
+
+    #[cfg(feature = "bench")]
     mod bench {
         use super::gen_test_img;
 


### PR DESCRIPTION
I ran into a situation where I tried to push in a hash of a zero-length value, and instead of erroring, it paniced! This PR fixes the problem, but my Rust is still not very good so I haven't figured out how to write the test correctly. If anyone has any thoughts about how to fix the commented out code, that'd be much appreciated.