### PR TITLE
Improve hash_image tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,11 @@ nightly = []
 
 [dependencies]
 base64 = ">=0.10,<0.14"
-image = { version = ">=0.21,<0.24", default-features = false }
+image = { version = ">=0.23.14", default-features = false, features = ["png", "jpeg"] }
 rustdct = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 transpose = "0.2"
+"clap" = "2.33.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/bin/hash_image.rs
+++ b/src/bin/hash_image.rs
@@ -5,21 +5,28 @@ extern crate image;
 
 use img_hash::HasherConfig;
 
-use std::env;
-
 fn main() -> Result<(), String> {
-    let args = env::args().collect::<Vec<_>>();
-    assert_eq!(args.len(), 2);
+    let matches = clap::App::new("hash_image")
+    .version("3.2.0")
+    .arg(
+        clap::Arg::with_name("IMAGE")
+            .required(true)
+            .index(1)
+            .help("Image file to calculate hash over.")
+    )
+    .get_matches();
 
-    let image = image::open(&args[1]).map_err(|e| {
-        format!("failed to open {}: {}", &args[1], e)
+    let image_file = matches.value_of("IMAGE").unwrap();
+
+    let image = image::open(image_file).map_err(|e| {
+        format!("failed to open {}: {}", image_file, e)
     })?;
 
     let hash = HasherConfig::new().hash_size(8, 8).to_hasher().hash_image(&image);
 
     let hash_str = hash.as_bytes().iter().map(|b| format!("{:02x}", b)).collect::<String>();
 
-    println!("{}: {}", &args[1], hash_str);
+    println!("{}: {}", image_file, hash_str);
 
     Ok(())
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -188,7 +188,7 @@ impl Image for DynamicImage {
     type Buf = image::RgbaImage;
 
     fn to_grayscale(&self) -> Cow<GrayImage> {
-        self.as_luma8().map_or_else(|| Cow::Owned(self.to_luma()), Cow::Borrowed)
+        self.as_luma8().map_or_else(|| Cow::Owned(self.to_luma8()), Cow::Borrowed)
     }
 
     fn blur(&self, sigma: f32) -> Self::Buf { imageops::blur(self, sigma) }


### PR DESCRIPTION
The current crate is not practical in that the `hash_image` binary does not have default features enables, so it can't read formats like png or jpg.

This pull request provides the following

* More robust argument handling in `hash_image` via `clap` crate.
* turns on `png` and `jpg` features on `image` crate so the tool is useful.
* Updates `image` crate to later version, corrects associated warnings.