### PR TITLE
Change Blockhash Link to Wayback Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A library for getting perceptual hash values of images.
 Thanks to Dr. Neal Krawetz for the outlines of the Mean (aHash), Gradient (dHash), and DCT (pHash) perceptual hash algorithms:  
 http://www.hackerfactor.com/blog/?/archives/432-Looks-Like-It.html (Accessed August 2014)
 
-Also provides an implementation of [the Blockhash.io algorithm](http://blockhash.io).
+Also provides an implementation of [the Blockhash.io algorithm](https://web.archive.org/web/20200119143207/http://blockhash.io/).
 
 This crate can operate directly on buffers from the [PistonDevelopers/image][1] crate.
 


### PR DESCRIPTION
The original Blockhash domain is no longer valid. Changing the link to the latest Wayback Machine snapshot prior to README.md's last commit.